### PR TITLE
Dismiss the dialog when tapping in empty area(with an option in initializer)

### DIFF
--- a/PopupDialog/Classes/PopupDialog.swift
+++ b/PopupDialog/Classes/PopupDialog.swift
@@ -72,6 +72,9 @@ final public class PopupDialog: UIViewController {
         messageText = message
         self.image = image
         self.buttonAlignment = buttonAlignment
+        
+        let tap = UITapGestureRecognizer(target: self, action: "handleTap:")
+        view.addGestureRecognizer(tap)
     }
 
     // Init with coder not implemented
@@ -79,6 +82,19 @@ final public class PopupDialog: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 }
+
+// MARK: Handle gesture
+
+extension PopupDialog {
+    
+    func handleTap(gesture: UITapGestureRecognizer) {
+        guard gesture.state == .Ended else {
+            return
+        }
+        presentingViewController?.dismissViewControllerAnimated(true, completion: nil)
+    }
+}
+
 
 // MARK: View lifecycle
 

--- a/PopupDialog/Classes/PopupDialog.swift
+++ b/PopupDialog/Classes/PopupDialog.swift
@@ -51,14 +51,15 @@ final public class PopupDialog: UIViewController {
      - parameter title:   The dialog title
      - parameter message: The dialog body
      - parameter image:   The image displayed on top
-
+     - parameter quickDismiss: dismiss the dialog when tapping in empty area
      - returns: Popup dialog view
      */
     public init(title: String?,
                 message: String?,
                 image: UIImage? = nil,
                 transitionStyle: PopupDialogTransitionStyle = .BounceUp,
-                buttonAlignment: UILayoutConstraintAxis = .Vertical) {
+                buttonAlignment: UILayoutConstraintAxis = .Vertical,
+                quickDismiss: Bool = true) {
 
         presentationManager = PopupDialogPresentationManager(transitionStyle: transitionStyle)
         super.init(nibName: nil, bundle: nil)
@@ -73,8 +74,11 @@ final public class PopupDialog: UIViewController {
         self.image = image
         self.buttonAlignment = buttonAlignment
         
-        let tap = UITapGestureRecognizer(target: self, action: "handleTap:")
-        view.addGestureRecognizer(tap)
+        if quickDismiss {
+            let tap = UITapGestureRecognizer(target: self, action: "handleTap:")
+            view.addGestureRecognizer(tap)
+        }
+
     }
 
     // Init with coder not implemented


### PR DESCRIPTION
Awesome lib! I just made a small adjustment to allow to dismiss the dialog when tapping in empty area. The option defaults to true because I think it is what a user expects in most situations.
