### PR TITLE
minor changes for Swift 2.3 compatibility

### DIFF
--- a/PopupDialog/Classes/PresentationController.swift
+++ b/PopupDialog/Classes/PresentationController.swift
@@ -32,10 +32,13 @@ final internal class PresentationController: UIPresentationController {
         return PopupDialogOverlayView(frame: .zero)
     }()
 
-    override init(presentedViewController: UIViewController, presentingViewController: UIViewController) {
+    override init(presentedViewController: UIViewController, presentingViewController: UIViewController?) {
         super.init(presentedViewController: presentedViewController, presentingViewController: presentingViewController)
-        overlay.blurView.underlyingView = presentingViewController.view
-        overlay.frame = presentingViewController.view.bounds
+
+        if let presentingController = presentingViewController {
+          overlay.blurView.underlyingView = presentingController.view
+          overlay.frame = presentingController.view.bounds
+        }
     }
 
     override func presentationTransitionWillBegin() {

--- a/PopupDialog/Classes/PresentationManager.swift
+++ b/PopupDialog/Classes/PresentationManager.swift
@@ -37,7 +37,7 @@ final internal class PresentationManager: NSObject, UIViewControllerTransitionin
         super.init()
     }
 
-    func presentationControllerForPresentedViewController(presented: UIViewController, presentingViewController presenting: UIViewController, sourceViewController source: UIViewController) -> UIPresentationController? {
+    func presentationControllerForPresentedViewController(presented: UIViewController, presentingViewController presenting: UIViewController?, sourceViewController source: UIViewController) -> UIPresentationController? {
         let presentationController = PresentationController(presentedViewController: presented, presentingViewController: source)
         return presentationController
     }

--- a/PopupDialog/Classes/TransitionAnimator.swift
+++ b/PopupDialog/Classes/TransitionAnimator.swift
@@ -51,7 +51,7 @@ internal class TransitionAnimator: NSObject, UIViewControllerAnimatedTransitioni
         case .In:
             to = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey)!
             from = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey)!
-            let container = transitionContext.containerView()!
+            let container = transitionContext.containerView()
             container.addSubview(to.view)
         case .Out:
             to = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey)!


### PR DESCRIPTION
Minor syntax modifications needed to support Swift 2.3 (on XCode Beta 6):
- Make the `presentationViewController` param an optional to conform to `UIPresentationController`, as it is now an optional.
- Remove the force unwrap of a `containerView()` on transitionContext, as it's no longer an optional.
