### PR TITLE
[Swift2.3] Remove force-unwrap containerView 

### DIFF
--- a/PopupDialog/Classes/TransitionAnimator.swift
+++ b/PopupDialog/Classes/TransitionAnimator.swift
@@ -52,7 +52,7 @@ internal class TransitionAnimator: NSObject, UIViewControllerAnimatedTransitioni
             to = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey)!
             from = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey)!
             let container = transitionContext.containerView()
-            container!.addSubview(to.view)
+            container.addSubview(to.view)
         case .Out:
             to = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey)!
             from = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey)!


### PR DESCRIPTION
- `UIViewControllerContextTransitioning containerView()` no longer optional
