### PR TITLE
CocoaPods: Fixed swift 2.3 compatibility for TZStackView dependency

### DIFF
--- a/PopupDialog.podspec
+++ b/PopupDialog.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.source_files = 'PopupDialog/Classes/**/*'
-  s.dependency 'TZStackView'
+  s.dependency 'TZStackView', '~> 1.2.0'
 end

--- a/PopupDialog.podspec
+++ b/PopupDialog.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.source_files = 'PopupDialog/Classes/**/*'
-  s.dependency 'TZStackView', '~> 1.2.0'
+  s.dependency 'TZStackView', '1.2.0'
 end


### PR DESCRIPTION
TZStackView's master branch also migrated to swift 3 so it breaks this repo's compatibility.