### PR TITLE
Expose popup container view

### DIFF
--- a/PopupDialog/Classes/PopupDialog.swift
+++ b/PopupDialog/Classes/PopupDialog.swift
@@ -65,6 +65,11 @@ final public class PopupDialog: UIViewController {
     /// Whether or not to shift view for keyboard display
     public var keyboardShiftsView = true
 
+    /// View containing the popup dialog and any buttons
+    public var popupDialogContainerView: UIView {
+        return popupContainerView.container
+    }
+
     // MARK: - Initializers
 
     /*!


### PR DESCRIPTION
Hi Martin, awesome project and very versatile. A request: We'd like to add a UI adornment to our `PopupDialog`, below the bottom of the alert itself, and, as far as we can tell, no view containing the actual popup is exposed to which we could attach layout constraints. Would you be open to exposing such a view as a read-only property to allow such customizations? (Or let me know if we are missing something and this is already possible...)