### PR TITLE
Fixed bug with keyboard

### DIFF
--- a/PopupDialog/Classes/PopupDialog.swift
+++ b/PopupDialog/Classes/PopupDialog.swift
@@ -173,10 +173,10 @@ final public class PopupDialog: UIViewController {
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        addObservers()
 
         guard !initialized else { return }
         appendButtons()
-        addObservers()
         initialized = true
     }
 


### PR DESCRIPTION
Fixed bug when, after showing other ViewController while dialog still open, keyboard shifting stop working