### PR TITLE
Separate tap gesture and pan gesture for dismiss dialog

### DIFF
--- a/Example/PopupDialog/ViewController.swift
+++ b/Example/PopupDialog/ViewController.swift
@@ -97,7 +97,8 @@ class ViewController: UIViewController {
                                 message: message,
                                 buttonAlignment: .horizontal,
                                 transitionStyle: .zoomIn,
-                                gestureDismissal: true,
+                                tapGestureDismissal: true,
+                                panGestureDismissal: true,
                                 hideStatusBar: true) {
             print("Completed")
         }
@@ -129,8 +130,12 @@ class ViewController: UIViewController {
         let ratingVC = RatingViewController(nibName: "RatingViewController", bundle: nil)
 
         // Create the dialog
-        let popup = PopupDialog(viewController: ratingVC, buttonAlignment: .horizontal, transitionStyle: .bounceDown, gestureDismissal: true)
-
+        let popup = PopupDialog(viewController: ratingVC,
+                                buttonAlignment: .horizontal,
+                                transitionStyle: .bounceDown,
+                                tapGestureDismissal: true,
+                                panGestureDismissal: false)
+        
         // Create first button
         let buttonOne = CancelButton(title: "CANCEL", height: 60) {
             self.label.text = "You canceled the rating dialog"

--- a/PopupDialog/Classes/PopupDialog.swift
+++ b/PopupDialog/Classes/PopupDialog.swift
@@ -83,7 +83,8 @@ final public class PopupDialog: UIViewController {
      - parameter buttonAlignment:  The dialog button alignment
      - parameter transitionStyle:  The dialog transition style
      - parameter preferredWidth:   The preferred width for iPad screens
-     - parameter gestureDismissal: Indicates if dialog can be dismissed via pan gesture
+     - parameter tapGestureDismissal: Indicates if dialog can be dismissed via tap gesture
+     - parameter panGestureDismissal: Indicates if dialog can be dismissed via pan gesture
      - parameter hideStatusBar:    Whether to hide the status bar on PopupDialog presentation
      - parameter completion:       Completion block invoked when dialog was dismissed
 
@@ -96,7 +97,8 @@ final public class PopupDialog: UIViewController {
                 buttonAlignment: UILayoutConstraintAxis = .vertical,
                 transitionStyle: PopupDialogTransitionStyle = .bounceUp,
                 preferredWidth: CGFloat = 340,
-                gestureDismissal: Bool = true,
+                tapGestureDismissal: Bool = true,
+                panGestureDismissal: Bool = true,
                 hideStatusBar: Bool = false,
                 completion: (() -> Void)? = nil) {
 
@@ -111,7 +113,8 @@ final public class PopupDialog: UIViewController {
                   buttonAlignment: buttonAlignment,
                   transitionStyle: transitionStyle,
                   preferredWidth: preferredWidth,
-                  gestureDismissal: gestureDismissal,
+                  tapGestureDismissal: tapGestureDismissal,
+                  panGestureDismissal: panGestureDismissal,
                   hideStatusBar: hideStatusBar,
                   completion: completion)
     }
@@ -123,7 +126,8 @@ final public class PopupDialog: UIViewController {
      - parameter buttonAlignment:  The dialog button alignment
      - parameter transitionStyle:  The dialog transition style
      - parameter preferredWidth:   The preferred width for iPad screens
-     - parameter gestureDismissal: Indicates if dialog can be dismissed via pan gesture
+     - parameter tapGestureDismissal: Indicates if dialog can be dismissed via tap gesture
+     - parameter panGestureDismissal: Indicates if dialog can be dismissed via pan gesture
      - parameter hideStatusBar:    Whether to hide the status bar on PopupDialog presentation
      - parameter completion:       Completion block invoked when dialog was dismissed
 
@@ -134,7 +138,8 @@ final public class PopupDialog: UIViewController {
         buttonAlignment: UILayoutConstraintAxis = .vertical,
         transitionStyle: PopupDialogTransitionStyle = .bounceUp,
         preferredWidth: CGFloat = 340,
-        gestureDismissal: Bool = true,
+        tapGestureDismissal: Bool = true,
+        panGestureDismissal: Bool = true,
         hideStatusBar: Bool = false,
         completion: (() -> Void)? = nil) {
 
@@ -163,14 +168,17 @@ final public class PopupDialog: UIViewController {
         popupContainerView.buttonStackView.axis = buttonAlignment
         viewController.didMove(toParentViewController: self)
 
-        // Allow for dialog dismissal on background tap and dialog pan gesture
-        if gestureDismissal {
-            let panRecognizer = UIPanGestureRecognizer(target: interactor, action: #selector(InteractiveTransition.handlePan))
-            popupContainerView.stackView.addGestureRecognizer(panRecognizer)
+        // Allow for dialog dismissal on background tap
+        if tapGestureDismissal {
             let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
             tapRecognizer.cancelsTouchesInView = false
-            panRecognizer.cancelsTouchesInView = false
             popupContainerView.addGestureRecognizer(tapRecognizer)
+        }
+        // Allow for dialog dismissal on dialog pan gesture
+        if panGestureDismissal {
+            let panRecognizer = UIPanGestureRecognizer(target: interactor, action: #selector(InteractiveTransition.handlePan))
+            panRecognizer.cancelsTouchesInView = false
+            popupContainerView.stackView.addGestureRecognizer(panRecognizer)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ public convenience init(
     buttonAlignment: UILayoutConstraintAxis = .vertical,
     transitionStyle: PopupDialogTransitionStyle = .bounceUp,
     preferredWidth: CGFloat = 340,
-    gestureDismissal: Bool = true,
+    tapGestureDismissal: Bool = true,
+    panGestureDismissal: Bool = true,
     hideStatusBar: Bool = false,
     completion: (() -> Void)? = nil) 
 ```
@@ -140,7 +141,8 @@ public init(
     buttonAlignment: UILayoutConstraintAxis = .vertical,
     transitionStyle: PopupDialogTransitionStyle = .bounceUp,
     preferredWidth: CGFloat = 340,
-    gestureDismissal: Bool = true,
+    tapGestureDismissal: Bool = true,
+    panGestureDismissal: Bool = true,
     hideStatusBar: Bool = false,
     completion: (() -> Void)? = nil) 
 ```
@@ -180,7 +182,7 @@ PopupDialog will always try to have a max width of 340 . On iPhones with smaller
 
 ## Gesture Dismissal
 
-Gesture dismissal allows your dialog being dismissed either by a background tap or by swiping the dialog down. By default, this is set to `true`. You can prevent this behavior by setting `gestureDismissal` to `false` in the initializer.
+Gesture dismissal allows your dialog being dismissed either by a background tap or by swiping the dialog down. By default, this is set to `true`. You can prevent this behavior by setting either `tapGestureDismissal` or `panGestureDismissal`  to `false` in the initializer.
 
 ## Hide Status Bar
 
@@ -395,7 +397,8 @@ PopupDialog *popup = [[PopupDialog alloc] initWithTitle: @"Title"
                                         buttonAlignment: UILayoutConstraintAxisVertical
                                         transitionStyle: PopupDialogTransitionStyleBounceUp
                                          preferredWidth: 380
-                                       gestureDismissal: NO
+                                    tapGestureDismissal: NO
+                                    panGestureDismissal: NO
                                           hideStatusBar: NO
                                              completion: nil];
 


### PR DESCRIPTION
I guess some users like me want to manage dismissal gestures separately. I split merged gestureDismissal to tapGestureDismissal and panGestureDismissal.

I think the best way to solve this wish is making DismissalGesture enum, and pass it to initializer as an array. So that initializer can determine which gestures will used for dismissal. But, because of my lack of knowledge, I have no idea how to support Swift enum array in Objective-C. (Cannot use swift enum array in Objective-C)

Let's find better solution later 😄 

FYI. I also edited readme.