### PR TITLE
Attributed message on popup

### DIFF
--- a/PopupDialog/Classes/PopupDialogDefaultViewController.swift
+++ b/PopupDialog/Classes/PopupDialogDefaultViewController.swift
@@ -70,6 +70,15 @@ public extension PopupDialogDefaultViewController {
         }
     }
 
+    /// The attributed message text of the dialog
+    public var attributedMessageText: NSAttributedString? {
+        get { return standardView.messageLabel.attributedText }
+        set {
+            standardView.messageLabel.attributedText = newValue
+            standardView.pv_layoutIfNeededAnimated()
+        }
+    }
+
     // MARK: Appearance
 
     /// The font and size of the title label

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ vc.titleText = "..."
 vc.messageText = "..."
 vc.buttonAlignment = .horizontal
 vc.transitionStyle = .bounceUp
+
+// You may also set attributed message on the dialog, 
+vc.attributedMessageText = NSAttributedString(...)
 ```
 
 <p>&nbsp;</p>


### PR DESCRIPTION
Added ability to use `NSAttributedString` as popup message.

Once merged, one could use `NSAttributedString` as the popup for the message as shown below:

```swift
 let popupVC = popup.viewController as! PopupDialogDefaultViewController
 popupVC.attributedMessageText = NSAttributedString(...)
```