### PR TITLE
- explicitly set used swift version to 4.2

### DIFF
--- a/PopupDialog.podspec
+++ b/PopupDialog.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '9.0'
   s.source_files = 'PopupDialog/Classes/**/*'
+  s.swift_version = '4.2'
 
   s.dependency 'DynamicBlurView', '~> 3.0.1'
 end


### PR DESCRIPTION
Could you please set the version of used swift language explicitly to 4.2?