### PR TITLE
preferredStatusBarStyle inherit from childViewController

### DIFF
--- a/Example/PopupDialog/Info.plist
+++ b/Example/PopupDialog/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Example/PopupDialog/RatingViewController.swift
+++ b/Example/PopupDialog/RatingViewController.swift
@@ -10,6 +10,10 @@ import UIKit
 
 class RatingViewController: UIViewController {
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
     @IBOutlet weak var cosmosStarRating: CosmosView!
 
     @IBOutlet weak var commentTextField: UITextField!

--- a/PopupDialog/Classes/PopupDialog.swift
+++ b/PopupDialog/Classes/PopupDialog.swift
@@ -307,6 +307,10 @@ final public class PopupDialog: UIViewController {
     public override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
         return .slide
     }
+
+    public override var childForStatusBarStyle: UIViewController? {
+        return viewController
+    }
 }
 
 // MARK: - View proxy values


### PR DESCRIPTION
At the moment it is not possible to change the status bar style of a popupdialog. ViewController provides a overridable property called `childForStatusBarStyle`. From this viewController (if it exists) it fetches the `preferredStatusBarStyle` automatically. I updated the examples to show the behaviour on the Rating Popup.

![Simulator Screen Shot - iPhone 11 - 2019-10-17 at 11 04 14](https://user-images.githubusercontent.com/735281/66994664-e906a700-f0cd-11e9-86e7-ffe499ea4a5b.png)
