### PR TITLE
Added SPM as install option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ DerivedData
 # Pods/
 .idea
 /Tests/FailureDiffs
+xcshareddata
+.build

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "DynamicBlurView",
+        "repositoryURL": "https://github.com/KyoheiG3/DynamicBlurView.git",
+        "state": {
+          "branch": null,
+          "revision": "fbf91352ff3defee8e1fc7525696404bc3740a86",
+          "version": "5.0.4"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,35 +12,35 @@ let package = Package(
 	name: "PopupDialog",
 	// Which platforms and minimum deployment targets are supported
 	// See: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#supportedplatform
-    platforms: [
-        .iOS(.v12),
-    ],
+	platforms: [
+		.iOS(.v12)
+	],
 	// The externaly visible build artifacts
 	// See: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#product
-    products: [
+	products: [
 		// Products define the executables and libraries produced by a package, and make them visible to other packages.
 		// The library that you can actually import
-        .library(
-            name: "PopupDialog",
-            targets: ["PopupDialog"]),
-    ],
+		.library(
+			name: "PopupDialog",
+			targets: ["PopupDialog"])
+	],
 	// Your package might need other packages.
 	// Due to being decentralized you have to tell SPM where to look.
-    dependencies: [
+	dependencies: [
 		// Dependencies declare other packages that this package depends on.
 		// .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/KyoheiG3/DynamicBlurView.git", from: "5.0.0"),
-    ],
+		.package(url: "https://github.com/KyoheiG3/DynamicBlurView.git", from: "5.0.0")
+	],
 	// Targets are the basic building blocks of a package. A target can define a module or a test suite.
 	// Targets can depend on other targets in this package, and on products in packages which this package depends on.
 	// See: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#target
-    targets: [
+	targets: [
 
-        .target(
-            name: "PopupDialog",
+		.target(
+			name: "PopupDialog",
 			dependencies:[
-				.product(name: "DynamicBlurView", package: "DynamicBlurView"),
-			],//["DynamicBlurView"],
-			path: "PopupDialog/Classes"),
-    ]
+				.product(name: "DynamicBlurView", package: "DynamicBlurView")
+			],
+			path: "PopupDialog/Classes")
+	]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,6 @@ import PackageDescription
 
 let package = Package(
 	name: "PopupDialog",
-    //name: "PopupDialog",
 	// Which platforms and minimum deployment targets are supported
 	// See: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#supportedplatform
     platforms: [
@@ -32,13 +31,11 @@ let package = Package(
 		// .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/KyoheiG3/DynamicBlurView.git", from: "5.0.0"),
     ],
-	// The basic building blocks.
+	// Targets are the basic building blocks of a package. A target can define a module or a test suite.
+	// Targets can depend on other targets in this package, and on products in packages which this package depends on.
 	// See: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#target
     targets: [
-		// Targets are the basic building blocks of a package. A target can define a module or a test suite.
-		// Targets can depend on other targets in this package, and on products in packages which this package depends on.
-		// Our package contains two targets, one for our library
-		// code, and one for our tests:
+
         .target(
             name: "PopupDialog",
 			dependencies: ["DynamicBlurView"],

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,9 @@ let package = Package(
 
         .target(
             name: "PopupDialog",
-			dependencies: ["DynamicBlurView"],
+			dependencies:[
+				.product(name: "DynamicBlurView", package: "DynamicBlurView"),
+			],//["DynamicBlurView"],
 			path: "PopupDialog/Classes"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,47 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+// This comment is necessary, and every Package.swift file
+// must start with it.
+// It tells SPM which version to use.
+// It doesn't have to be the same version as your code,
+// but it should be compatible.
+
+import PackageDescription
+
+let package = Package(
+	name: "PopupDialog",
+    //name: "PopupDialog",
+	// Which platforms and minimum deployment targets are supported
+	// See: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#supportedplatform
+    platforms: [
+        .iOS(.v12),
+    ],
+	// The externaly visible build artifacts
+	// See: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#product
+    products: [
+		// Products define the executables and libraries produced by a package, and make them visible to other packages.
+		// The library that you can actually import
+        .library(
+            name: "PopupDialog",
+            targets: ["PopupDialog"]),
+    ],
+	// Your package might need other packages.
+	// Due to being decentralized you have to tell SPM where to look.
+    dependencies: [
+		// Dependencies declare other packages that this package depends on.
+		// .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/KyoheiG3/DynamicBlurView.git", from: "5.0.0"),
+    ],
+	// The basic building blocks.
+	// See: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#target
+    targets: [
+		// Targets are the basic building blocks of a package. A target can define a module or a test suite.
+		// Targets can depend on other targets in this package, and on products in packages which this package depends on.
+		// Our package contains two targets, one for our library
+		// code, and one for our tests:
+        .target(
+            name: "PopupDialog",
+			dependencies: ["DynamicBlurView"],
+			path: "PopupDialog/Classes"),
+    ]
+)

--- a/PopupDialog/Classes/InteractiveTransition.swift
+++ b/PopupDialog/Classes/InteractiveTransition.swift
@@ -24,6 +24,7 @@
 //
 
 import Foundation
+import UIKit
 
 // Handles interactive transition triggered via pan gesture recognizer on dialog
 final internal class InteractiveTransition: UIPercentDrivenInteractiveTransition {

--- a/PopupDialog/Classes/PopupDialogOverlayView.swift
+++ b/PopupDialog/Classes/PopupDialogOverlayView.swift
@@ -25,6 +25,7 @@
 
 import Foundation
 import DynamicBlurView
+import UIKit
 
 /// The (blurred) overlay view below the popup dialog
 final public class PopupDialogOverlayView: UIView {


### PR DESCRIPTION
Swift Package Manager
You can use [Swift Package Manager](https://swift.org/package-manager/) to install Popupdialog using Xcode:

1. Open your project in Xcode

2. Click "File" -> "Swift Packages" -> "Add Package Dependency..."

3. Paste the following URL: 

4. Click "Next" -> "Next" -> "Finish"